### PR TITLE
Adding a Gemfile and remote the jruby-openssl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'rake'
+gem 'gem_publisher'
+gem 'archive-tar-minitar'

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -21,9 +21,6 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
-
-  s.add_runtime_dependency 'murmurhash3'
-  s.add_runtime_dependency 'jruby-openssl', ['0.9.4']
-
+  s.add_runtime_dependency "murmurhash3"                      #(MIT license)
 end
 


### PR DESCRIPTION
- Missing Gemfile
- Remove jruby-open ssl its already included in jruby 1.7.6
