### PR TITLE
Fix the PUNCTUATION method issue with non ascii characters

### DIFF
--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -62,7 +62,10 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
       when "PUNCTUATION"
         @source.sort.each do |field|
           next unless event.include?(field)
-          event[@target] = event[field].tr('A-Za-z0-9 \t','')
+          # In order to keep some backwards compatibility we should use the unicode version
+          # of the regexp because the POSIX one ([[:punct:]]) left some unwanted characters unfiltered (Symbols).
+          # gsub(/[^[:punct:]]/,'') should be equivalent to gsub(/[^[\p{P}\p{S}]]/,''), but not 100% in JRuby.
+          event[@target] = event[field].gsub(/[^[\p{P}\p{S}]]/,'')
         end
       else
         if @concatenate_sources

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-fingerprint'
-  s.version         = '0.1.5'
+  s.version         = '0.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Fingerprint fields using by replacing values with a consistent hash."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -160,6 +160,10 @@ describe LogStash::Filters::Fingerprint do
     sample("field1" =>  "PHP Warning:  json_encode() [<a href='function.json-encode'>function.json-encode</a>]: Invalid UTF-8 sequence in argument in /var/www/htdocs/test.php on line 233") do
       insist { subject["fingerprint"] } == ":_()[<='.-'>.-</>]:-////."
     end
+
+    sample("field1" => "Warning: Ruby(ルビ) is an awesome language.") do
+      insist { subject["fingerprint"] } == ":()."
+    end
   end
 
   context 'Timestamps' do


### PR DESCRIPTION
Fixed, and make more standard, the PUNCTUATION issue (#4) with non ascii characters being not filtered.

_Note_

The situation where the characters that one might think are punctuation are actually symbols, for example the ```<``` and ```>```. In the case of the ```[[:punct:]]``` POSIX syntax this characters are not deal with, so it's better to use the more general UNICODE syntax for that.