### PR TITLE
Improve clarity of key config requirement

### DIFF
--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -33,8 +33,8 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   # Any current contents of that field will be overwritten.
   config :target, :validate => :string, :default => 'fingerprint'
 
+  # Key is required with all methods except  `MURMUR3`, `PUNCTUATION` or `UUID`.
   # When used with the `IPV4_NETWORK` method fill in the subnet prefix length.
-  # Not required for `MURMUR3`, `PUNCTUATION` or `UUID` methods.
   # With other methods fill in the HMAC key.
   config :key, :validate => :string
 


### PR DESCRIPTION
Make it clearer when the key config is mandatory.