### PR TITLE
Option to automatically include all field names in fingerprint

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,6 +45,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-base64encode>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-concatenate_sources>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-concatenate_all_fields>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-method>> |<<string,string>>, one of `["SHA1", "SHA256", "SHA384", "SHA512", "MD5", "MURMUR3", "IPV4_NETWORK", "UUID", "PUNCTUATION"]`|Yes
 | <<plugins-{type}s-{plugin}-source>> |<<array,array>>|No
@@ -77,6 +78,19 @@ plugin concatenates the names and values of all fields given in the
 doing the fingerprint computation. If `false` and multiple source
 fields are given, the target field will be an array with fingerprints
 of the source fields given.
+
+[id="plugins-{type}s-{plugin}-concatenate_all_fields"]
+===== `concatenate_sources` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When set to `true` and `method` isn't `UUID` or `PUNCTUATION`, the
+plugin concatenates the names and values of all fields of the event 
+into one string (like the old checksum filter) before doing the 
+fingerprint computation. If `false` and at least one source field is 
+given, the target field will be an array with fingerprints of the 
+source fields given.
 
 [id="plugins-{type}s-{plugin}-key"]
 ===== `key` 

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -165,8 +165,7 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
       hash  = OpenSSL::HMAC.digest(@digest, @key, data.to_s)
       Base64.strict_encode64(hash).force_encoding(Encoding::UTF_8)
     else
-      hash = OpenSSL::HMAC.hexdigest(@digest, @key, data.to_s).force_encoding(Encoding::UTF_8)
-      return hash
+      OpenSSL::HMAC.hexdigest(@digest, @key, data.to_s).force_encoding(Encoding::UTF_8)
     end
   end
 

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -51,6 +51,23 @@ describe LogStash::Filters::Fingerprint do
     end
   end
 
+  describe "fingerprint string with SHA1 alogrithm on all event fields" do
+    config <<-CONFIG
+      filter {
+        fingerprint {
+          concatenate_all_fields => true
+          key => "longencryptionkey"
+          method => 'SHA1'
+        }
+      }
+    CONFIG
+
+    # The @timestamp field is specified in this sample event as we need the event contents to be constant for the tests
+    sample("@timestamp" => "2017-07-26T14:44:27.064Z", "clientip" => "123.123.123.123", "message" => "This is a test message", "log_level" => "INFO", "offset" => 123456789, "type" => "test") do
+      insist { subject.get("fingerprint") } == "d7c617f4d40b2cb677a7003af68a41c415f58031"
+    end
+  end
+
   describe "fingerprint string with SHA1 alogrithm and base64 encoding" do
     config <<-CONFIG
       filter {


### PR DESCRIPTION
Although I realize this can definitely be more computationally expensive, it does come in handy when you may have many types of events, that may change in structure on a regular basis.