### PR TITLE
Fixed documentation for concatenate_all_fields

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -80,7 +80,7 @@ fields are given, the target field will be an array with fingerprints
 of the source fields given.
 
 [id="plugins-{type}s-{plugin}-concatenate_all_fields"]
-===== `concatenate_sources` 
+===== `concatenate_all_fields` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`


### PR DESCRIPTION
Noticed that the documentation was lacking the description for `concatenate_all_fields` so have fixed it.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
