### PR TITLE
Fix non-deterministic fingerprint for nested hashes by sorting

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -69,14 +69,13 @@ base64 encoded rather than hex encoded strings.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-When set to `true` and either `concatenate_sources` or
-`concatenate_all_fields` is set then the input fields will be deep sorted when
+When set to `true` then the input fields will be deep sorted when
 serializing prior to fingerprint calculation.
 This is needed when you have nested hashes because otherwise the order of
-the inner hashes is non-deterministc and is going to result in different
+the inner hashes is non-deterministic and is going to result in different
 fingerprints for the same inputs.
 
-When you just start using this plugin, it should be save to set `deep_sort`
+When you just start using this plugin, it should be safe to set `deep_sort`
 to `true` from the beginning. The reason this is not the default is because
 the serialization format changes with `deep_sort` even if there are no
 nested hashes.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -63,6 +63,24 @@ filter plugins.
 When set to `true`, the `SHA1`, `SHA256`, `SHA384`, `SHA512` and `MD5` fingerprint methods will produce
 base64 encoded rather than hex encoded strings.
 
+[id="plugins-{type}s-{plugin}-deep_sort"]
+===== `deep_sort`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When set to `true` and either `concatenate_sources` or
+`concatenate_all_fields` is set then the input fields will be deep sorted when
+serializing prior to fingerprint calculation.
+This is needed when you have nested hashes because otherwise the order of
+the inner hashes is non-deterministc and is going to result in different
+fingerprints for the same inputs.
+
+When you just start using this plugin, it should be save to set `deep_sort`
+to `true` from the beginning. The reason this is not the default is because
+the serialization format changes with `deep_sort` even if there are no
+nested hashes.
+
 [id="plugins-{type}s-{plugin}-concatenate_sources"]
 ===== `concatenate_sources` 
 

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -83,6 +83,24 @@ describe LogStash::Filters::Fingerprint do
     end
   end
 
+  describe "fingerprint string with SHA1 HMAC algorithm on all event fields with deep_sort" do
+    config <<-CONFIG
+      filter {
+        fingerprint {
+          concatenate_all_fields => true
+          key => "longencryptionkey"
+          method => 'SHA1'
+          deep_sort => true
+        }
+      }
+    CONFIG
+
+    # The @timestamp field is specified in this sample event as we need the event contents to be constant for the tests
+    sample("@timestamp" => "2017-07-26T14:44:27.064Z", "clientip" => "123.123.123.123", "message" => "This is a test message", "log_level" => "INFO", "offset" => 123456789, "type" => "test", "beat" => {"hostname" => "gnu.example.com", "name" => "gnu.example.com", "version" => "5.2.2"}) do
+      insist { subject.get("fingerprint") } == "e39ef60e5fb431aa7f9847a4591bf1ffe49cd410"
+    end
+  end
+
   describe "fingerprint string with SHA1 algorithm and base64 encoding" do
     config <<-CONFIG
       filter {


### PR DESCRIPTION
Consider this example:

```JSON
{
  "@timestamp": "2023-05-23T23:23:23.555Z",
  "@version": "1",
  "beat": {
    "hostname": "gnu.example.com",
    "name": "gnu.example.com",
    "version": "5.2.2"
  },
  "host": "gnu.example.com"
}
```

Using this filter:

```Logstash
fingerprint {
  concatenate_all_fields => true
  target => "[@metadata][_id]"
  method => "SHA512"
  key => "XXX"
  base64encode => true
}
```

Here, the order of the `.beat` hash is non-deterministic and the plugin did not do a deep sort as part of the serialization. This resulted in different fingerprints for the same event because the order of the three keys (hostname, name, version) changed randomly in the serialization.

This has been fixed by recursively checking for hashes and serializing them in sorted order.

Note that this changes the serialization format and thus breaks backwards compatibility. The old format could be emulated in order to not break backwards compatibility. Backwards compatibility in this case means to generate the same fingerprint for the same input. This is also the reason why the unit test on Travis fails.