### PR TITLE
Support to exclude fields from `concatenate_all_fields`

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -89,6 +89,15 @@ fingerprint computation. If `false` and at least one source field is
 given, the target field will be an array with fingerprints of the 
 source fields given.
 
+[id="plugins-{type}s-{plugin}-exclude"]
+===== `exclude` 
+
+  * Value type is <<array,array>>
+  * Default value is ``
+
+The name(s) of field(s) to exclude when `concatenate_all_fields` is set to
+`true`.
+
 [id="plugins-{type}s-{plugin}-key"]
 ===== `key` 
 


### PR DESCRIPTION
Status: Feature complete. Need to rebase and fix/add unit tests ontop of #41.
This implements #43

I plan to rebase when #41 is merged because I developed those two features in a row as I needed them for our environment. Feel free to review this already: https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/44/commits/42e8f2321401a57b24eede54f7f786e4c921f7ee