### PR TITLE
Add support for excluding fields from all concatenated fields

### DIFF
--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -78,7 +78,10 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   config :concatenate_all_fields, :validate => :boolean, :default => false
   
   # Excluded fields from all concatenated fields. Can be applied only if
-  # `concatenate_all_fields` is set.
+  # `concatenate_all_fields` is set. For excluding nested key from the event
+  # use nested list in `exclude_sources` (e.g. excluding event["a"] and 
+  # event["b"]["cc"] from `event = {"a": 1, "b": { "bb": 2, "cc": 3 }}` 
+  # use `exclude_sources => ["a", ["b", "cc"]]`).
   config :exclude_sources, :validate => :array, :default => []
 
   def register

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -142,7 +142,8 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
     else
       if @concatenate_sources || @concatenate_all_fields
         to_string = ""
-        if @concatenate_all_fields
+        if @concatenate_all_fields 
+          hash_event = event.to_hash         
           if @exclude_sources.any?
             event_sources = JSON.parse(event.to_json)
             @exclude_sources.each do |key|
@@ -152,11 +153,10 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
                 event_sources.delete(key)
               end
             end
-            to_string << JSON.generate(event_sources)
-          else
-            event.to_hash.sort.map do |k,v|
-              to_string << "|#{k}|#{v}"
-            end
+            hash_event = event_sources
+          end
+          hash_event.sort.map do |k,v|
+            to_string << "|#{k}|#{v}"
           end
         else
           @source.sort.each do |k|

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -6,7 +6,6 @@ require "openssl"
 require "ipaddr"
 require "murmurhash3"
 require "securerandom"
-require "json"
 
 # Create consistent hashes (fingerprints) of one or more fields and store
 # the result in a new field.
@@ -145,7 +144,7 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
         if @concatenate_all_fields 
           hash_event = event.to_hash         
           if @exclude_sources.any?
-            event_sources = JSON.parse(event.to_json)
+            event_sources = hash_event
             @exclude_sources.each do |key|
               if key.is_a?(Array)
                 nested_delete(event_sources, key)


### PR DESCRIPTION
I found it more difficult to include multiple fields from large data set, rather than excluding one or more fields from all concatenated fields. It is tested and working feature in my production ELK stack. 