### PR TITLE
deeply sort hashes to ensure consistent fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.2
+  - Fixed lack of consistent fingerprints on Hash/Map objects [#55](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/55)
+
 ## 3.2.1
   - Fixed concurrent SHA fingerprinting by making the instances thread local
 

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-fingerprint'
-  s.version         = '3.2.1'
+  s.version         = '3.2.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Fingerprints fields by replacing values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fingerprinting is done by either fetching the .to_hash representation
or by fetching fields with .get(field)

The content of these often contain hashes, which we don't guarantee
order during insertion, so this commit recursively sorts hashes.

This happens in all modes:
* concatenate_all_sources
* concatenate_fields
* normal single field fingerprint

NOTE: I propose we don't consider this a breaking change (therefore not requiring a major version bump). The current ordering is unpredictable and therefore is much more of a bug than a feature. The only two paths forward would have been:
1. sorting hashes like we do here
2. only allowing fingerprinting on scalar fields (and therefore removing `concatenate_all_sources`)

Option 2 was much more likely to produce breaking changes, so we went here with 1.

Fixes #39
Replaces #41, #52 