### PR TITLE
fix broken Murmur3 with number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.2.4
-  - Fixed the error in Murmur3 with Integer
+  - Fixed the error in Murmur3 with Integer [#61](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/61)
 
 ## 3.2.3
   - [DOC] Expanded description for concatenate_sources behavior and provided examples [#60](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.4
+  - Fixed the error in Murmur3 with Integer
+
 ## 3.2.3
   - [DOC] Expanded description for concatenate_sources behavior and provided examples [#60](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/60)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -156,7 +156,7 @@ the cryptographic hash function with the same name will be used to generate
 the fingerprint. When a key set, the keyed-hash (HMAC) digest function will
 be used.
 
-If set to `MURMUR3` the non-cryptographic MurmurHash function will be used.
+If set to `MURMUR3` the non-cryptographic 64 bit MurmurHash function will be used.
 
 If set to `IPV4_NETWORK` the input data needs to be a IPv4 address and
 the hash value will be the masked-out address using the number of bits

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -193,8 +193,8 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
 
   def fingerprint_murmur3(value)
     case value
-    when Fixnum
-      MurmurHash3::V32.int_hash(value)
+    when Integer
+      MurmurHash3::V32.int64_hash(value)
     else
       MurmurHash3::V32.str_hash(value.to_s)
     end

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-fingerprint'
-  s.version         = '3.2.3'
+  s.version         = '3.2.4'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Fingerprints fields by replacing values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -32,8 +32,18 @@ describe LogStash::Filters::Fingerprint do
     describe "the MURMUR3 method" do
       let(:fingerprint_method) { "MURMUR3" }
 
-      it "fingerprints the value" do
-        expect(fingerprint).to eq(4013733395)
+      context "string" do
+        it "fingerprints the value" do
+          expect(fingerprint).to eq(4013733395)
+        end
+      end
+
+      context "number" do
+        let(:data) { {"clientip" => 123 } }
+
+        it "fingerprints the value" do
+          expect(fingerprint).to eq(823512154)
+        end
       end
     end
 


### PR DESCRIPTION
- `int_hash` is not a valid method name. It should be either `int64_hash` or `int32_hash`
- Fixnum is deprecated in favour of Integer

Fixed #16 
