### PR TITLE
added support for 128-bit MURMUR3 variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.4.0
-  - [DOC] Added support for 128bit murmur variant [#66](https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/66) (resolves [#32](https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/32), supercedes [#42](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/42)).
+  - Added support for 128bit murmur variant [#66](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/66).
 
 ## 3.3.2
   - [DOC] Clarify behavior when key is set [#65](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/65). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.0
+  - [DOC] Added support for 128bit murmur variant [#66](https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/66) (resolves [#32](https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/32), supercedes [#42](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/42)).
+
 ## 3.3.2
   - [DOC] Clarify behavior when key is set [#65](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/65). 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -60,7 +60,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-concatenate_all_fields>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-method>> |<<string,string>>, one of `["SHA1", "SHA256", "SHA384", "SHA512", "MD5", "MURMUR3", "IPV4_NETWORK", "UUID", "PUNCTUATION"]`|Yes
+| <<plugins-{type}s-{plugin}-method>> |<<string,string>>, one of `["SHA1", "SHA256", "SHA384", "SHA512", "MD5", "MURMUR3", "MURMUR3_128", IPV4_NETWORK", "UUID", "PUNCTUATION"]`|Yes
 | <<plugins-{type}s-{plugin}-source>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
@@ -174,7 +174,7 @@ With other methods, optionally fill in the HMAC key.
 ===== `method` 
 
   * This is a required setting.
-  * Value can be any of: `SHA1`, `SHA256`, `SHA384`, `SHA512`, `MD5`, `MURMUR3`, `IPV4_NETWORK`, `UUID`, `PUNCTUATION`
+  * Value can be any of: `SHA1`, `SHA256`, `SHA384`, `SHA512`, `MD5`, `MURMUR3`, `MURMUR3_128`, `IPV4_NETWORK`, `UUID`, `PUNCTUATION`
   * Default value is `"SHA1"`
 
 The fingerprint method to use.
@@ -183,7 +183,7 @@ If set to `SHA1`, `SHA256`, `SHA384`, `SHA512`, or `MD5` and a key is set, the
 corresponding cryptographic hash function and the keyed-hash (HMAC) digest function
 are used to generate the fingerprint.
 
-If set to `MURMUR3` the non-cryptographic 64 bit MurmurHash function will be used.
+If set to `MURMUR3` or `MURMUR3_128` the non-cryptographic MurmurHash function (either the 32-bit or 128-bit implementation, respectively) will be used.
 
 If set to `IPV4_NETWORK` the input data needs to be a IPv4 address and
 the hash value will be the masked-out address using the number of bits

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -76,7 +76,7 @@ filter plugins.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-When set to `true`, the `SHA1`, `SHA256`, `SHA384`, `SHA512` and `MD5` fingerprint methods will produce
+When set to `true`, the `SHA1`, `SHA256`, `SHA384`, `SHA512`, `MD5` and `MURMUR3_128` fingerprint methods will produce
 base64 encoded rather than hex encoded strings.
 
 [id="plugins-{type}s-{plugin}-concatenate_sources"]

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -64,7 +64,7 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   # If set to `UUID`, a
   # https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID] will
   # be generated. The result will be random and thus not a consistent hash.
-  config :method, :validate => ['SHA1', 'SHA256', 'SHA384', 'SHA512', 'MD5', "MURMUR3", "IPV4_NETWORK", "UUID", "PUNCTUATION"], :required => true, :default => 'SHA1'
+  config :method, :validate => ['SHA1', 'SHA256', 'SHA384', 'SHA512', 'MD5', "MURMUR3", "MURMUR3_128", "IPV4_NETWORK", "UUID", "PUNCTUATION"], :required => true, :default => 'SHA1'
 
   # When set to `true` and `method` isn't `UUID` or `PUNCTUATION`, the
   # plugin concatenates the names and values of all fields given in the
@@ -102,6 +102,8 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
       class << self; alias_method :fingerprint, :fingerprint_ipv4_network; end
     when :MURMUR3
       class << self; alias_method :fingerprint, :fingerprint_murmur3; end
+    when :MURMUR3_128
+      class << self; alias_method :fingerprint, :fingerprint_murmur3_128; end
     when :UUID
       # nothing
     when :PUNCTUATION
@@ -207,6 +209,17 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
       MurmurHash3::V32.int64_hash(value)
     else
       MurmurHash3::V32.str_hash(value.to_s)
+    end
+  end
+
+  def fingerprint_murmur3_128(value)
+    case value
+    when Fixnum
+      MurmurHash3::V128.int32_hash(value, 2)
+    when Bignum
+      MurmurHash3::V128.int64_hash(value, 2)
+    else
+      MurmurHash3::V128.str_hash(value.to_s, 2)
     end
   end
 

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -24,8 +24,8 @@ require "logstash/plugin_mixins/ecs_compatibility_support"
 # To generate UUIDs, prefer the <<plugins-filters-uuid,uuid filter>>.
 class LogStash::Filters::Fingerprint < LogStash::Filters::Base
 
-  MAX_32BIT = (1 << 31) - 1
-  MIN_32BIT = -(1 << 31)
+  INTEGER_MAX_32BIT = (1 << 31) - 1
+  INTEGER_MIN_32BIT = -(1 << 31)
 
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
 
@@ -44,8 +44,8 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   # With other methods, optionally fill in the HMAC key.
   config :key, :validate => :string
 
-  # When set to `true`, the `SHA1`, `SHA256`, `SHA384`, `SHA512` and `MD5` fingerprint methods will produce
-  # base64 encoded rather than hex encoded strings.
+  # When set to `true`, the `SHA1`, `SHA256`, `SHA384`, `SHA512`, `MD5` and `MURMUR3_128` fingerprint
+  # methods will produce base64 encoded rather than hex encoded strings.
   config :base64encode, :validate => :boolean, :default => false
 
   # The fingerprint method to use.
@@ -220,7 +220,7 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
 
   def fingerprint_murmur3_128(value)
     if value.is_a?(Integer)
-      if (MIN_32BIT <= value) && (value <= MAX_32BIT)
+      if (INTEGER_MIN_32BIT <= value) && (value <= INTEGER_MAX_32BIT)
         if @base64encode
           [MurmurHash3::V128.int32_hash(value, 2).pack("L*")].pack("m").chomp!
         else

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -56,7 +56,7 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   # be used.
   #
   # If set to `MURMUR3` or `MURMUR3_128` the non-cryptographic MurmurHash
-  # function (either the 32-bit or 128-bit implementation, repsectively)
+  # function (either the 32-bit or 128-bit implementation, respectively)
   # will be used.
   #
   # If set to `IPV4_NETWORK` the input data needs to be a IPv4 address and

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "murmurhash3"                    #(MIT license)
   s.add_development_dependency 'logstash-devutils'
-  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
 end

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "murmurhash3"                      #(MIT license)
+  s.add_runtime_dependency "murmurhash3"                    #(MIT license)
   s.add_development_dependency 'logstash-devutils'
-  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support'
 end
-

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-fingerprint'
-  s.version         = '3.3.2'
+  s.version         = '3.4.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Fingerprints fields by replacing values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -297,7 +297,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
         let(:fingerprint_method) { "MURMUR3_128" }
         let(:data) { { "@timestamp" => epoch_time } }
         it "fingerprints the timestamp correctly" do
-          expect(fingerprint).to eq("61df5cc024b8fa8895bed59b65e52e52")
+          expect(fingerprint).to eq("37785b62a8cae473acc315d39b66d86e")
         end
       end
     end

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -50,6 +50,59 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
         end
       end
 
+      describe "the MURMUR3_128 method" do
+        let(:fingerprint_method) { "MURMUR3_128" }
+
+        context "string hex encoding" do
+          it "fingerprints the value" do
+            expect(fingerprint).to eq("41cbc4056eed401d091dfbeabf7ea9e0")
+          end
+        end
+
+        context "string base64 encoding" do
+          let(:config) { super().merge("base64encode" => true) }
+          it "fingerprints the value" do
+            expect(fingerprint).to eq("QcvEBW7tQB0JHfvqv36p4A==")
+          end
+        end
+
+        context "int32 hex encoding" do
+          let(:config) { super().merge("base64encode" => false) }
+          let(:data) { {"clientip" => 123 } }
+
+          it "fingerprints the value" do
+            expect(fingerprint).to eq("286816c693ac410ed63e1430dcd6f6fe")
+          end
+        end
+
+        context "int32 base64 encoding" do
+          let(:config) { super().merge("base64encode" => true) }
+          let(:data) { {"clientip" => 123 } }
+
+          it "fingerprints the value" do
+            expect(fingerprint).to eq("KGgWxpOsQQ7WPhQw3Nb2/g==")
+          end
+        end
+
+        context "int64 hex encoding" do
+          let(:config) { super().merge("base64encode" => false) }
+          let(:data) { {"clientip" => 2148483647 } }
+
+          it "fingerprints the value" do
+            expect(fingerprint).to eq("fdc7699a82556c8c584131f0133ee989")
+          end
+        end
+
+        context "int64 base64 encoding" do
+          let(:config) { super().merge("base64encode" => true) }
+          let(:data) { {"clientip" => 2148483647 } }
+
+          it "fingerprints the value" do
+            expect(fingerprint).to eq("/cdpmoJVbIxYQTHwEz7piQ==")
+          end
+        end
+      end
+
       describe "the SHA1 method" do
         let(:fingerprint_method) { "SHA1" }
 
@@ -237,6 +290,14 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
         let(:data) { { "@timestamp" => epoch_time } }
         it "fingerprints the timestamp correctly" do
           expect(fingerprint).to eq(743372282)
+        end
+      end
+
+      describe 'MURMUR3_128 Fingerprinting' do
+        let(:fingerprint_method) { "MURMUR3_128" }
+        let(:data) { { "@timestamp" => epoch_time } }
+        it "fingerprints the timestamp correctly" do
+          expect(fingerprint).to eq("61df5cc024b8fa8895bed59b65e52e52")
         end
       end
     end


### PR DESCRIPTION
As #42 hasn't been updated in some years, this PR takes the commit from that one and makes the following additions. This resolves #32 (at least as far as it applies to murmur3).

* modifies the CHANGELOG as requested by @kaisecheng
* changes the version number as requested by @kaisecheng
* adds tests as requested by @kaisecheng
* honors the convention of default hex-encoded vs. `base64encode` fingerprint representations (since unlike the 32-bit variant which just produces an integer the 128-bit functions in the [murmurhash3-ruby](https://github.com/funny-falcon/murmurhash3-ruby) library return an array of integers)

I'm running some more tests and whatnot now but I think this is ready for review.