### PR TITLE
Change key config type to `Password`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.2
+  - Key config type changed to `Password` type for better protection from leaks. [#70](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/70)
+
 ## 3.4.1
   - Added backward compatibility of timestamp format to provide consistent fingerprint [#67](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/67)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.4.2
-  - Key config type changed to `Password` type for better protection from leaks. [#70](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/70)
+  - Key config type changed to `Password` type for better protection from leaks. [#71](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/71)
 
 ## 3.4.1
   - Added backward compatibility of timestamp format to provide consistent fingerprint [#67](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/67)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,7 +59,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-concatenate_sources>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-concatenate_all_fields>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
-| <<plugins-{type}s-{plugin}-key>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-key>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-method>> |<<string,string>>, one of `["SHA1", "SHA256", "SHA384", "SHA512", "MD5", "MURMUR3", "MURMUR3_128", IPV4_NETWORK", "UUID", "PUNCTUATION"]`|Yes
 | <<plugins-{type}s-{plugin}-source>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
@@ -164,7 +164,7 @@ See <<plugins-{type}s-{plugin}-ecs_metadata>> for detailed information.
 [id="plugins-{type}s-{plugin}-key"]
 ===== `key` 
 
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 When used with the `IPV4_NETWORK` method fill in the subnet prefix length.

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -61,7 +61,7 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
 
   # When used with the `IPV4_NETWORK` method fill in the subnet prefix length.
   # With other methods, optionally fill in the HMAC key.
-  config :key, :validate => :string
+  config :key, :validate => :password
 
   # When set to `true`, the `SHA1`, `SHA256`, `SHA384`, `SHA512`, `MD5` and `MURMUR3_128` fingerprint
   # methods will produce base64 encoded rather than hex encoded strings.
@@ -199,7 +199,7 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
 
   def fingerprint_ipv4_network(ip_string)
     # in JRuby 1.7.11 outputs as US-ASCII
-    IPAddr.new(ip_string).mask(@key.to_i).to_s.force_encoding(Encoding::UTF_8)
+    IPAddr.new(ip_string).mask(@key.value.to_i).to_s.force_encoding(Encoding::UTF_8)
   end
 
   def fingerprint_openssl(data)
@@ -220,10 +220,10 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
       end
     else
       if @base64encode
-        hash = OpenSSL::HMAC.digest(digest, @key, data.to_s)
+        hash = OpenSSL::HMAC.digest(digest, @key.value, data.to_s)
         Base64.strict_encode64(hash).force_encoding(Encoding::UTF_8)
       else
-        OpenSSL::HMAC.hexdigest(digest, @key, data.to_s).force_encoding(Encoding::UTF_8)
+        OpenSSL::HMAC.hexdigest(digest, @key.value, data.to_s).force_encoding(Encoding::UTF_8)
       end
     end
   end

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-fingerprint'
-  s.version         = '3.4.1'
+  s.version         = '3.4.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Fingerprints fields by replacing values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -29,7 +29,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
 
       describe "the IPV4_NETWORK method" do
         let(:fingerprint_method) { "IPV4_NETWORK" }
-        let(:config) { super().merge("key" => 24) }
+        let(:config) { super().merge("key" => ::LogStash::Util::Password.new("24")) }
 
         it "fingerprints the ip as the network" do
           expect(fingerprint).to eq("123.123.123.0")
@@ -115,7 +115,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
         end
 
         context "with HMAC" do
-          let(:config) { super().merge("key" => "longencryptionkey") }
+          let(:config) { super().merge("key" => ::LogStash::Util::Password.new("longencryptionkey")) }
 
           it "fingerprints the value" do
             expect(fingerprint).to eq("fdc60acc4773dc5ac569ffb78fcb93c9630797f4")
@@ -141,7 +141,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
           expect(fingerprint).to eq("4dabcab210766e35f03e77120e6986d6e6d4752b2a9ff22980b9253d026080d8")
         end
         context "with HMAC" do
-          let(:config) { super().merge("key" => "longencryptionkey") }
+          let(:config) { super().merge("key" => ::LogStash::Util::Password.new("longencryptionkey")) }
           it "fingerprints the value" do
             expect(fingerprint).to eq("345bec3eff242d53b568916c2610b3e393d885d6b96d643f38494fd74bf4a9ca")
           end
@@ -160,7 +160,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
           expect(fingerprint).to eq("fd605b0a3af3e04ce0d7a0b0d9c48d67a12dab811f60072e6eae84e35d567793ffb68a1807536f11c90874065c2a4392")
         end
         context "with HMAC" do
-          let(:config) { super().merge("key" => "longencryptionkey") }
+          let(:config) { super().merge("key" => ::LogStash::Util::Password.new("longencryptionkey")) }
           it "fingerprints the value" do
             expect(fingerprint).to eq("22d4c0e8c4fbcdc4887d2038fca7650f0e2e0e2457ff41c06eb2a980dded6749561c814fe182aff93e2538d18593947a")
           end
@@ -178,7 +178,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
           expect(fingerprint).to eq("5468e2dc64ea92b617782aae884b35af60041ac9e168a283615b6a462c54c13d42fa9542cce9b7d76a8124ac6616818905e3e5dd35d6e519f77c3b517558639a")
         end
         context "with HMAC" do
-          let(:config) { super().merge("key" => "longencryptionkey") }
+          let(:config) { super().merge("key" => ::LogStash::Util::Password.new("longencryptionkey")) }
           it "fingerprints the value" do
             expect(fingerprint).to eq("11c19b326936c08d6c50a3c847d883e5a1362e6a64dd55201a25f2c1ac1b673f7d8bf15b8f112a4978276d573275e3b14166e17246f670c2a539401c5bfdace8")
           end
@@ -196,7 +196,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
           expect(fingerprint).to eq("ccdd8d3d940a01b2fb3258c059924c0d")
         end
         context "with HMAC" do
-          let(:config) { super().merge("key" => "longencryptionkey") }
+          let(:config) { super().merge("key" => ::LogStash::Util::Password.new("longencryptionkey")) }
           it "fingerprints the value" do
             expect(fingerprint).to eq("9336c879e305c9604a3843fc3e75948f")
           end
@@ -281,7 +281,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
       let(:config) { super().merge("source" => ['@timestamp']) }
 
       describe 'OpenSSL Fingerprinting' do
-        let(:config) { super().merge("key" => '0123') }
+        let(:config) { super().merge("key" => ::LogStash::Util::Password.new("0123")) }
         let(:fingerprint_method) { "SHA1" }
         let(:data) { { "@timestamp" => epoch_time } }
         it "fingerprints the timestamp correctly" do


### PR DESCRIPTION
### Description
This PR ensures to protect the `:key` from leaks in the debug logs.

- Closes #70 

### Test
```
# config
Config:
      input {
        stdin {}
      }
      filter {
          fingerprint {
            key => "super-secret"
          }
      }
      output {
          stdout {
              codec => rubydebug
          }
      }
```


```
# Log before change
[2022-12-05T11:15:06,403][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"fingerprint", :type=>"filter", :class=>LogStash::Filters::Fingerprint}
[2022-12-05T11:15:06,406][DEBUG][logstash.filters.fingerprint] config LogStash::Filters::Fingerprint/@key = "super-secret"

# Log after change
[2022-12-05T11:17:12,124][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"fingerprint", :type=>"filter", :class=>LogStash::Filters::Fingerprint}
[2022-12-05T11:17:12,128][DEBUG][logstash.filters.fingerprint] config LogStash::Filters::Fingerprint/@key = <password>
```

```
# Unit tests
 mashhur:☆ rspec logstash-plugins/logstash-filter-fingerprint/spec/filters/fingerprint_spec.rb
    Sending Logstash logs to null which is now configured via log4j2.properties
    Run options: exclude {:integration=>true, :redis=>true, :socket=>true, :performance=>true, :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true, :export_cypher=>true, :windows=>true}

    Randomized with seed 63435
    .................................................................................................................................

    Finished in 0.83772 seconds (files took 6.94 seconds to load)
    129 examples, 0 failures

    Randomized with seed 63435
```