### PR TITLE
Eagerly load OpenSSL module to avoid resolution during multithreaded access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.4
+  - Fix, eagerly load OpenSSL classes ot avoid uninitialized constant error [#76](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/76)
+
 ## 3.4.3
   - pin murmurhash3 to 0.1.6 [#74](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/74)
 

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -134,6 +134,9 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
     when :PUNCTUATION
       # nothing
     else
+      # force the resolution of OpenSSL class to avoid errors when loaded in multithreaded
+      # #select_digest method. https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/75
+      OpenSSL::Digest::MD5
       class << self; alias_method :fingerprint, :fingerprint_openssl; end
     end
   end

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -134,9 +134,10 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
     when :PUNCTUATION
       # nothing
     else
-      # force the resolution of OpenSSL class to avoid errors when loaded in multithreaded
-      # #select_digest method. https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/75
-      OpenSSL::Digest::MD5
+      # force the resolution of OpenSSL class to avoid errors when loaded in multi-threaded
+      # #fingerprint_openssl method to instantiate the appropriate digest class.
+      # https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/75
+      select_digest(@method)
       class << self; alias_method :fingerprint, :fingerprint_openssl; end
     end
   end
@@ -212,7 +213,10 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
     # we must include the id in the thread local variable name, so that we can
     # store multiple digest instances
     digest_string = "digest-#{id}"
-    Thread.current[digest_string] ||= select_digest(@method)
+    unless Thread.current[digest_string]
+      digest_class = select_digest(@method)
+      Thread.current[digest_string] = digest_class.new
+    end
     digest = Thread.current[digest_string]
     # in JRuby 1.7.11 outputs as ASCII-8BIT
     if @key.nil?
@@ -264,18 +268,19 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
     end
   end
 
+  # Return Class reference more appropriate for the method.
   def select_digest(method)
     case method
     when :SHA1
-      OpenSSL::Digest::SHA1.new
+      OpenSSL::Digest::SHA1
     when :SHA256
-      OpenSSL::Digest::SHA256.new
+      OpenSSL::Digest::SHA256
     when :SHA384
-      OpenSSL::Digest::SHA384.new
+      OpenSSL::Digest::SHA384
     when :SHA512
-      OpenSSL::Digest::SHA512.new
+      OpenSSL::Digest::SHA512
     when :MD5
-      OpenSSL::Digest::MD5.new
+      OpenSSL::Digest::MD5
     else
       # we really should never get here
       raise(LogStash::ConfigurationError, "Unknown digest for method=#{method.to_s}")

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-fingerprint'
-  s.version         = '3.4.3'
+  s.version         = '3.4.4'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Fingerprints fields by replacing values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Release notes
Fix, eagerly load OpenSSL classes ot avoid uninitialized constant error.

## What does this PR do?

Move the loading of OpenSSL digest classes into `#register` method instead of instantiating them in the `#filter` method.
The first is accessed in single thread during pipeline creation, the second is accessed in multi-threaded fashion (one per worker) during processing of events phase. Limiting multithreaded access to reference the OpenSSL digest classes solves #75.

## Why is it important/What is the impact to the user?

Fix a bug that manifested in 30% of starts of pipelines which contains this filter.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Stop and start multiple times a Logstash which executes the following pipeline:
```
input {
 generator {
 	message => "sample test message"
 	count => 10000000
 }
}

filter {
 fingerprint {
   source => "message"
   target => "fingerprint"
   method => "MD5"
   key    => "epoch-1ki"
 }
}

output {
 sink {}
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #75

## Logs

```
[2024-03-06T10:50:30,407][ERROR][logstash.javapipeline    ][main] Pipeline worker error, the pipeline will be stopped {
	:pipeline_id=>"main", 
	:error=>"(NameError) uninitialized constant LogStash::Filters::Fingerprint::OpenSSL", 
	:exception=>Java::OrgJrubyExceptions::NameError, 
	:backtrace=>[
        "org.jruby.RubyModule.const_missing(org/jruby/RubyModule.java:3766)", 
```
