### PR TITLE
Fix Hash/Array fingerprint instability across JRuby versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0
+  - Fix fingerprint instability for Hash and Array field values caused by JRuby 10 changing `Hash#inspect` formatting [#79](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/79)
+
 ## 3.4.4
   - Fix, eagerly load OpenSSL classes ot avoid uninitialized constant error [#76](https://github.com/logstash-plugins/logstash-filter-fingerprint/pull/76)
 

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -160,12 +160,12 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
         if @concatenate_all_fields
           deep_sort_hashes(event.to_hash).each do |k,v|
             # Force encoding to UTF-8 to get around https://github.com/jruby/jruby/issues/6748
-            to_string << "|#{k}|#{to_canonical_string(v)}".force_encoding("UTF-8")
+            to_string << "|#{k}|#{to_canonical_value(v)}".force_encoding("UTF-8")
           end
         else
           @source.sort.each do |k|
             # Force encoding to UTF-8 to get around https://github.com/jruby/jruby/issues/6748
-            to_string << "|#{k}|#{to_canonical_string(event.get(k))}".force_encoding("UTF-8")
+            to_string << "|#{k}|#{to_canonical_value(event.get(k))}".force_encoding("UTF-8")
           end
         end
         to_string << "|"
@@ -175,9 +175,9 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
         @source.each do |field|
           next unless event.include?(field)
           if event.get(field).is_a?(Array)
-            event.set(@target, event.get(field).collect { |v| fingerprint(to_canonical_string(v)) })
+            event.set(@target, event.get(field).collect { |v| fingerprint(to_canonical_value(v)) })
           else
-            event.set(@target, fingerprint(to_canonical_string(event.get(field))))
+            event.set(@target, fingerprint(to_canonical_value(event.get(field))))
           end
         end
       end
@@ -201,15 +201,17 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
     end
   end
 
-  # Returns a canonical string representation of the given object.
-  # For Hashes and Arrays, produces a pipe-delimited format that is
+  # Returns a canonical representation of the given object for fingerprinting.
+  # For Hashes and Arrays, produces a pipe-delimited string that is
   # independent of Hash#inspect formatting (which changed in JRuby 10).
-  def to_canonical_string(object)
+  # Scalars pass through unchanged to preserve type-aware fingerprinting
+  # (e.g., MURMUR3 uses int64_hash for Integers vs str_hash for Strings).
+  def to_canonical_value(object)
     case object
     when Hash
-      object.sort.map { |k, v| "#{to_canonical_string(k)}|#{to_canonical_string(v)}" }.join("|")
+      object.sort.map { |k, v| "#{to_canonical_value(k)}|#{to_canonical_value(v)}" }.join("|")
     when Array
-      object.map { |e| to_canonical_string(e) }.join("|")
+      object.map { |e| to_canonical_value(e) }.join("|")
     else
       object
     end

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -160,12 +160,12 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
         if @concatenate_all_fields
           deep_sort_hashes(event.to_hash).each do |k,v|
             # Force encoding to UTF-8 to get around https://github.com/jruby/jruby/issues/6748
-            to_string << "|#{k}|#{v}".force_encoding("UTF-8")
+            to_string << "|#{k}|#{to_canonical_string(v)}".force_encoding("UTF-8")
           end
         else
           @source.sort.each do |k|
             # Force encoding to UTF-8 to get around https://github.com/jruby/jruby/issues/6748
-            to_string << "|#{k}|#{deep_sort_hashes(event.get(k))}".force_encoding("UTF-8")
+            to_string << "|#{k}|#{to_canonical_string(event.get(k))}".force_encoding("UTF-8")
           end
         end
         to_string << "|"
@@ -175,9 +175,9 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
         @source.each do |field|
           next unless event.include?(field)
           if event.get(field).is_a?(Array)
-            event.set(@target, event.get(field).collect { |v| fingerprint(deep_sort_hashes(v)) })
+            event.set(@target, event.get(field).collect { |v| fingerprint(to_canonical_string(v)) })
           else
-            event.set(@target, fingerprint(deep_sort_hashes(event.get(field))))
+            event.set(@target, fingerprint(to_canonical_string(event.get(field))))
           end
         end
       end
@@ -196,6 +196,20 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
       sorted_hash
     when Array
       object.map {|element| deep_sort_hashes(element) }
+    else
+      object
+    end
+  end
+
+  # Returns a canonical string representation of the given object.
+  # For Hashes and Arrays, produces a pipe-delimited format that is
+  # independent of Hash#inspect formatting (which changed in JRuby 10).
+  def to_canonical_string(object)
+    case object
+    when Hash
+      object.sort.map { |k, v| "#{to_canonical_string(k)}|#{to_canonical_string(v)}" }.join("|")
+    when Array
+      object.map { |e| to_canonical_string(e) }.join("|")
     else
       object
     end

--- a/logstash-filter-fingerprint.gemspec
+++ b/logstash-filter-fingerprint.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-fingerprint'
-  s.version         = '3.4.4'
+  s.version         = '3.5.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Fingerprints fields by replacing values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/fingerprint_spec.rb
+++ b/spec/filters/fingerprint_spec.rb
@@ -261,7 +261,7 @@ describe LogStash::Filters::Fingerprint, :ecs_compatibility_support, :aggregate_
         let(:config) { super().merge("concatenate_sources" => true) }
         it "fingerprints the value of concatenated key/pairs" do
           # SHA1 of "|field1|inner_key|🂡|1|2|field2|🂡|"
-          expect(fingerprint).to eq("d74f41841c7cdc793a97c218d2ff18064a5f1950")
+          expect(fingerprint).to eq("d2a1c14e0c9ef137d67114db23b3f2fdbcc90d08")
         end
       end
     end


### PR DESCRIPTION
JRuby 10 changed Hash#inspect spacing, producing different fingerprint bytes for nested Hash/Array fields. Use a  pipe-delimited format instead of relying on Hash#inspect.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/


Closes: https://github.com/logstash-plugins/logstash-filter-fingerprint/issues/78